### PR TITLE
处理node_modules文件过多的情况下，内存溢出问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/node_modules/
+.idea


### PR DESCRIPTION
详见 #1 

### 现象
如果node_modules 文件过多，在当前版本的实现中，会导致NodeJS内存溢出

### 调整
优化并发任务池 Pool，调整 collectElf 任务插入逻辑